### PR TITLE
handleCORS wildcard

### DIFF
--- a/pkg/api/middleware.go
+++ b/pkg/api/middleware.go
@@ -41,19 +41,10 @@ func (api *API) recoverPanic(next http.Handler) http.Handler {
 
 func (api *API) handleCORS(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		origin := r.Header.Get("Origin")
-		var allowedHost string
-		allowedHosts := []string{"https://www.ddstats.com", "http://www.ddstats.com", "http://ddstats.com", "https://ddstats.com"}
-		for _, host := range allowedHosts {
-			if host == origin {
-				allowedHost = host
-				break
-			}
-		}
 
 		// Set CORS headers for the preflight request
 		if r.Method == http.MethodOptions {
-			w.Header().Set("Access-Control-Allow-Origin", allowedHost)
+			w.Header().Set("Access-Control-Allow-Origin", "*")
 			w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS, GET, PUT, DELETE")
 			w.Header().Set("Access-Control-Allow-Credentials", "true")
 			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
@@ -62,7 +53,7 @@ func (api *API) handleCORS(next http.Handler) http.Handler {
 			return
 		}
 		// Set CORS headers for the main request.
-		w.Header().Set("Access-Control-Allow-Origin", allowedHost)
+		w.Header().Set("Access-Control-Allow-Origin", "*")
 		next.ServeHTTP(w, r)
 	})
 }


### PR DESCRIPTION
Now that the DB is handled separately, allowing all origins no longer poses a security risk, and makes it possible for other DD webapps (like DDLIVE) to ask for information directly, instead of routing through a CORS proxy.