### PR TITLE
Added DDLive links to discord embed

### DIFF
--- a/pkg/discord/discord.go
+++ b/pkg/discord/discord.go
@@ -80,7 +80,7 @@ func (d *Discord) listenForNotifications() {
 				go func() {
 					err := d.broadcast(&discordgo.MessageEmbed{
 						Title:       fmt.Sprintf("%s just passed their best time of %.4fs!", v.PlayerName, v.PreviousGameTime),
-						Description: fmt.Sprintf("Watch here: https://ddstats.com/players/%d", v.PlayerID),
+						Description: fmt.Sprintf("Watch on [DDStats](https://ddstats.com/players/%d) or [DDLive](https://ddstats.live/#x3y1&ppid=%[1]d)", v.PlayerID),
 					})
 					if err != nil {
 						d.errorLog.Printf("%+v", err)
@@ -90,7 +90,7 @@ func (d *Discord) listenForNotifications() {
 				go func() {
 					err := d.broadcast(&discordgo.MessageEmbed{
 						Title:       fmt.Sprintf("%s just got a new score of %.4fs!", v.PlayerName, v.GameTime),
-						Description: fmt.Sprintf("...beating their old high score of %.4fs by %.4f seconds!\nGame log here: https://ddstats.com/games/%d", v.PreviousGameTime, v.GameTime-v.PreviousGameTime, v.GameID),
+						Description: fmt.Sprintf("...beating their old high score of %.4fs by %.4f seconds!\nGame log on [DDStats](https://ddstats.com/games/%d) or [DDLive](https://ddstats.live/#x4y-1&gpid=%[3]d)", v.PreviousGameTime, v.GameTime-v.PreviousGameTime, v.GameID),
 					})
 					if err != nil {
 						d.errorLog.Printf("%+v", err)
@@ -100,7 +100,7 @@ func (d *Discord) listenForNotifications() {
 				go func() {
 					err := d.broadcast(&discordgo.MessageEmbed{
 						Title:       fmt.Sprintf("%s is above 1000!", v.PlayerName),
-						Description: fmt.Sprintf("Watch here: https://ddstats.com/players/%d", v.PlayerID),
+						Description: fmt.Sprintf("Watch on [DDStats](https://ddstats.com/players/%d) or [DDLive](https://ddstats.live/#x3y1&ppid=%[1]d)", v.PlayerID),
 					})
 					if err != nil {
 						d.errorLog.Printf("%+v", err)
@@ -110,7 +110,7 @@ func (d *Discord) listenForNotifications() {
 				go func() {
 					err := d.broadcast(&discordgo.MessageEmbed{
 						Title:       fmt.Sprintf("%s died at %.4f seconds!", v.PlayerName, v.GameTime),
-						Description: fmt.Sprintf("...%s\nGame log here: https://ddstats.com/games/%d", strings.ToLower(v.DeathType), v.GameID),
+						Description: fmt.Sprintf("...%s\nGame log on [DDStats](https://ddstats.com/games/%d) or [DDLive](https://ddstats.live/#x4y-1&gpid=%[2]d)", strings.ToLower(v.DeathType), v.GameID),
 					})
 					if err != nil {
 						d.errorLog.Printf("%+v", err)
@@ -120,7 +120,7 @@ func (d *Discord) listenForNotifications() {
 				go func() {
 					err := d.broadcast(&discordgo.MessageEmbed{
 						Title:       fmt.Sprintf("%s died at %.4f", v.PlayerName, v.GameTime),
-						Description: fmt.Sprintf("...%s\nGame log: https://ddstats.com/games/%d", strings.ToLower(v.DeathType), v.GameID),
+						Description: fmt.Sprintf("...%s\nGame log on [DDStats](https://ddstats.com/games/%d) or [DDLive](https://ddstats.live/#x4y-1&gpid=%[2]d)", strings.ToLower(v.DeathType), v.GameID),
 					})
 					if err != nil {
 						d.errorLog.Printf("%+v", err)


### PR DESCRIPTION
This adds DDLive links to the discord embed messages, and replaces the original long link with a new _fancy_ markdown link