### PR TITLE
Green the build: fix %w log misuse, stale test table

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -136,7 +136,7 @@ func main() {
 		srv.SetKeepAlivesEnabled(false)
 		err := srv.Shutdown(ctx)
 		if err != nil {
-			errorLog.Fatal("Could not gracefully shut down the server: %w", err)
+			errorLog.Fatalf("Could not gracefully shut down the server: %v", err)
 		}
 		close(done)
 	}()

--- a/pkg/api/helpers_test.go
+++ b/pkg/api/helpers_test.go
@@ -3,15 +3,16 @@ package api
 import "testing"
 
 func TestValidVersion(t *testing.T) {
+	// cases are tied to oldestValidClientVersion in api.go
 	tests := []struct {
 		version string
 		want    bool
 	}{
-		{"0.4.5", true},
-		{"0.4.0", true},
-		{"0.3.0", false},
-		{"0.3.1", true},
-		{"1.3.1", true},
+		{"0.5.9", false},
+		{"0.6.0", true},
+		{"0.6.1", true},
+		{"0.7.0", true},
+		{"1.0.0", true},
 		{"0.0.9", false},
 	}
 	for _, tt := range tests {

--- a/pkg/discord/command_global.go
+++ b/pkg/discord/command_global.go
@@ -22,10 +22,10 @@ func (d *Discord) commandGlobal() {
 			leaderboard, err := d.ddAPI.GetLeaderboard(0, 0)
 			if err != nil {
 				if errors.Is(err, ddapi.ErrStatusCode) {
-					d.errorLog.Printf("%w", err)
+					d.errorLog.Printf("%v", err)
 					return errorEmbed(fmt.Sprintf("Unable to access the Devil Daggers API. %s", m.Author.Mention()))
 				}
-				d.errorLog.Printf("%w", err)
+				d.errorLog.Printf("%v", err)
 				return errorEmbed(fmt.Sprintf("Some error occurred while calling !id. %s", m.Author.Mention()))
 			}
 			p := message.NewPrinter(language.English)

--- a/pkg/discord/command_help.go
+++ b/pkg/discord/command_help.go
@@ -19,7 +19,7 @@ func (d *Discord) commandHelp() {
 		getEmbed: func(m *discordgo.MessageCreate, args ...string) *discordgo.MessageEmbed {
 			userChannel, err := d.Session.UserChannelCreate(m.Author.ID)
 			if err != nil {
-				d.errorLog.Printf("error creating user channel for user %s with ID %s: %w", m.Author.Username, m.Author.ID, err)
+				d.errorLog.Printf("error creating user channel for user %s with ID %s: %v", m.Author.Username, m.Author.ID, err)
 				return errorEmbed(fmt.Sprintf("Unable to message you. Do you have DMs disabled? %s", m.Author.Mention()))
 			}
 			if len(args) == 0 {
@@ -39,7 +39,7 @@ func (d *Discord) commandHelp() {
 					},
 				})
 				if err != nil {
-					d.errorLog.Printf("error sending message to user channel for user %s with ID %s: %w", m.Author.Username, m.Author.ID, err)
+					d.errorLog.Printf("error sending message to user channel for user %s with ID %s: %v", m.Author.Username, m.Author.ID, err)
 					return errorEmbed(fmt.Sprintf("Unable to message you. Do you have DMs disabled? %s", m.Author.Mention()))
 				}
 				// if the incoming command is coming in through a DM, don't return

--- a/pkg/discord/command_id.go
+++ b/pkg/discord/command_id.go
@@ -30,13 +30,13 @@ func (d *Discord) commandID() {
 			player, err := d.ddAPI.UserByID(id)
 			if err != nil {
 				if errors.Is(err, ddapi.ErrStatusCode) {
-					d.errorLog.Printf("%w", err)
+					d.errorLog.Printf("%v", err)
 					return errorEmbed(fmt.Sprintf("Unable to access the Devil Daggers API. %s", m.Author.Mention()))
 				}
 				if errors.Is(err, ddapi.ErrPlayerNotFound) {
 					return errorEmbed(fmt.Sprintf("No players were found for Player ID %d. %s", id, m.Author.Mention()))
 				}
-				d.errorLog.Printf("%w", err)
+				d.errorLog.Printf("%v", err)
 				return errorEmbed(fmt.Sprintf("Some error occurred while calling !id. %s", m.Author.Mention()))
 			}
 			return &discordgo.MessageEmbed{

--- a/pkg/discord/command_me.go
+++ b/pkg/discord/command_me.go
@@ -31,19 +31,19 @@ func (d *Discord) commandMe() {
 						},
 					}
 				}
-				d.errorLog.Printf("%w", err)
+				d.errorLog.Printf("%v", err)
 				return errorEmbed(fmt.Sprintf("Database error while trying to retrieve user ID %q. %s", m.Author.ID, m.Author.Mention()))
 			}
 			player, err := d.ddAPI.UserByID(discordUser.DDID)
 			if err != nil {
 				if errors.Is(err, ddapi.ErrStatusCode) {
-					d.errorLog.Printf("%w", err)
+					d.errorLog.Printf("%v", err)
 					return errorEmbed(fmt.Sprintf("Unable to access the Devil Daggers API. %s", m.Author.Mention()))
 				}
 				if errors.Is(err, ddapi.ErrPlayerNotFound) {
 					return errorEmbed(fmt.Sprintf("No players were found for Player ID %d. %s", discordUser.DDID, m.Author.Mention()))
 				}
-				d.errorLog.Printf("%w", err)
+				d.errorLog.Printf("%v", err)
 				return errorEmbed(fmt.Sprintf("Some error occurred while calling !id. %s", m.Author.Mention()))
 			}
 			return &discordgo.MessageEmbed{

--- a/pkg/discord/command_rank.go
+++ b/pkg/discord/command_rank.go
@@ -32,13 +32,13 @@ func (d *Discord) commandRank() {
 			player, err := d.ddAPI.UserByRank(rank)
 			if err != nil {
 				if errors.Is(err, ddapi.ErrStatusCode) {
-					d.errorLog.Printf("%w", err)
+					d.errorLog.Printf("%v", err)
 					return errorEmbed(fmt.Sprintf("Unable to access the Devil Daggers API. %s", m.Author.Mention()))
 				}
 				if errors.Is(err, ddapi.ErrPlayerNotFound) {
 					return errorEmbed(fmt.Sprintf("No players were found for Player Rank %d. %s", rank, m.Author.Mention()))
 				}
-				d.errorLog.Printf("%w", err)
+				d.errorLog.Printf("%v", err)
 				return errorEmbed(fmt.Sprintf("Some error occurred while calling !id. %s", m.Author.Mention()))
 			}
 			return &discordgo.MessageEmbed{

--- a/pkg/discord/command_search.go
+++ b/pkg/discord/command_search.go
@@ -26,13 +26,13 @@ func (d *Discord) commandSearch() {
 			players, err := d.ddAPI.UserSearch(userName)
 			if err != nil {
 				if errors.Is(err, ddapi.ErrStatusCode) {
-					d.errorLog.Printf("%w", err)
+					d.errorLog.Printf("%v", err)
 					return errorEmbed(fmt.Sprintf("Unable to access the Devil Daggers API. %s", m.Author.Mention()))
 				}
 				if errors.Is(err, ddapi.ErrNoPlayersFound) {
 					return errorEmbed(fmt.Sprintf("No players were found for '%s'. %s", strings.Join(args, " "), m.Author.Mention()))
 				}
-				d.errorLog.Printf("%w", err)
+				d.errorLog.Printf("%v", err)
 				return errorEmbed(fmt.Sprintf("Some error occurred while calling !search. %s", m.Author.Mention()))
 			}
 			player := players[0]

--- a/pkg/discord/command_top.go
+++ b/pkg/discord/command_top.go
@@ -20,10 +20,10 @@ func (d *Discord) commandTop() {
 			leaderboard, err := d.ddAPI.GetLeaderboard(10, 0)
 			if err != nil {
 				if errors.Is(err, ddapi.ErrStatusCode) {
-					d.errorLog.Printf("%w", err)
+					d.errorLog.Printf("%v", err)
 					return errorEmbed(fmt.Sprintf("Unable to access the Devil Daggers API. %s", m.Author.Mention()))
 				}
-				d.errorLog.Printf("%w", err)
+				d.errorLog.Printf("%v", err)
 				return nil
 			}
 			// fields := make([]*discordgo.MessageEmbedField, 10)

--- a/pkg/discord/message_create.go
+++ b/pkg/discord/message_create.go
@@ -38,7 +38,7 @@ func (d *Discord) messageCreate(s *discordgo.Session, m *discordgo.MessageCreate
 	if since < command.cooldown {
 		_, err := s.ChannelMessageSend(m.ChannelID, fmt.Sprintf("The %s%s command is on cooldown. Please wait %s to use it. %s", prefix, command.name, command.cooldown-since, m.Author.Mention()))
 		if err != nil {
-			d.errorLog.Printf("%w", err)
+			d.errorLog.Printf("%v", err)
 		}
 		return
 	}
@@ -53,7 +53,7 @@ func (d *Discord) messageCreate(s *discordgo.Session, m *discordgo.MessageCreate
 	}
 	_, err := s.ChannelMessageSendEmbed(m.ChannelID, embed)
 	if err != nil {
-		d.errorLog.Printf("%w", err)
+		d.errorLog.Printf("%v", err)
 	}
 
 	// switch strings.ToLower(contentTokens[0]) {

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -10,12 +10,12 @@ import (
 	"gopkg.in/guregu/null.v3"
 )
 
-//ErrNoRecord will be returned when DB record not found
+// ErrNoRecord will be returned when DB record not found
 var ErrNoRecord = errors.New("no record found")
 var ErrNoDiscordUserFound = errors.New("no entry associated with that discord ID")
 var ErrDiscordUserVerified = errors.New("discord user is verified so cannot update their values")
 
-//Game record representation
+// Game record representation
 type Game struct {
 	ID                   int         `json:"id" db:"id"`
 	Rank                 int         `json:"rank,omitempty" db:"rank"`

--- a/pkg/socketio/socketio.go
+++ b/pkg/socketio/socketio.go
@@ -151,7 +151,7 @@ func (si *sio) onDisconnect(s socketio.Conn, msg string) {
 	player.Lock()
 	websocketMessage, err := websocket.NewMessage(strconv.Itoa(player.PlayerID), "submit", struct{}{})
 	if err != nil {
-		si.errorLog.Println("socketio onSubmit: %w", err)
+		si.errorLog.Printf("socketio onSubmit: %v", err)
 	}
 	si.websocketHub.Broadcast <- websocketMessage
 	si.livePlayers.Delete(s.ID())
@@ -193,7 +193,7 @@ func (si *sio) onStatusUpdate(s socketio.Conn, playerID, statusID int) {
 
 	websocketMessage, err := websocket.NewMessage(strconv.Itoa(playerID), "status", status)
 	if err != nil {
-		si.errorLog.Println("socketio status: %w", err)
+		si.errorLog.Printf("socketio status: %v", err)
 	}
 	si.websocketHub.Broadcast <- websocketMessage
 }
@@ -217,7 +217,7 @@ func (si *sio) onGameSubmitted(s socketio.Conn, gameID int, notifyPlayerBest, no
 		GameID:   gameID,
 	})
 	if err != nil {
-		si.errorLog.Println("socketio on game_submitted: %w", err)
+		si.errorLog.Printf("socketio on game_submitted: %v", err)
 	}
 	si.websocketHub.BroadcastToAll <- websocketMessage
 
@@ -237,7 +237,7 @@ func (si *sio) onGameSubmitted(s socketio.Conn, gameID int, notifyPlayerBest, no
 		})
 
 		if err != nil {
-			si.errorLog.Println("socketio on game_submitted: %w", err)
+			si.errorLog.Printf("socketio on game_submitted: %v", err)
 		}
 
 		si.websocketHub.BroadcastToAll <- websocketMessage
@@ -259,7 +259,7 @@ func (si *sio) onGameSubmitted(s socketio.Conn, gameID int, notifyPlayerBest, no
 		})
 
 		if err != nil {
-			si.errorLog.Println("socketio on game_submitted: %w", err)
+			si.errorLog.Printf("socketio on game_submitted: %v", err)
 		}
 
 		si.websocketHub.BroadcastToAll <- websocketMessage
@@ -277,7 +277,7 @@ func (si *sio) onLogin(s socketio.Conn, id int) {
 
 	p, err := si.ddAPI.UserByID(id)
 	if err != nil {
-		si.errorLog.Printf("socketio onLogin: %w", err)
+		si.errorLog.Printf("socketio onLogin: %v", err)
 		s.Close()
 		return
 	}
@@ -294,7 +294,7 @@ func (si *sio) onLogin(s socketio.Conn, id int) {
 
 	err = si.db.Players.UpsertDDPlayer(p)
 	if err != nil {
-		si.errorLog.Printf("socketio onLogin: %w", err)
+		si.errorLog.Printf("socketio onLogin: %v", err)
 		s.Close()
 		return
 	}
@@ -303,7 +303,7 @@ func (si *sio) onLogin(s socketio.Conn, id int) {
 
 	websocketMessage, err := websocket.NewMessage(strconv.Itoa(int(p.PlayerID)), "submit", struct{}{})
 	if err != nil {
-		si.errorLog.Println("socketio onSubmit: %w", err)
+		si.errorLog.Printf("socketio onSubmit: %v", err)
 	}
 	si.websocketHub.Broadcast <- websocketMessage
 
@@ -363,7 +363,7 @@ func (si *sio) onStateUpdate(s socketio.Conn, playerID int, gameTime float64, ge
 	player.websocketPlayer.Unlock()
 	websocketMessage, err := websocket.NewMessage(strconv.Itoa(playerID), "submit", state)
 	if err != nil {
-		si.errorLog.Println("socketio onSubmit: %w", err)
+		si.errorLog.Printf("socketio onSubmit: %v", err)
 		return
 	}
 	si.websocketHub.Broadcast <- websocketMessage
@@ -383,7 +383,7 @@ func (si *sio) onStateUpdate(s socketio.Conn, playerID int, gameTime float64, ge
 		})
 
 		if err != nil {
-			si.errorLog.Println("socketio on status_update: %w", err)
+			si.errorLog.Printf("socketio on status_update: %v", err)
 		}
 
 		si.websocketHub.BroadcastToAll <- websocketMessage
@@ -401,7 +401,7 @@ func (si *sio) onStateUpdate(s socketio.Conn, playerID int, gameTime float64, ge
 		})
 
 		if err != nil {
-			si.errorLog.Println("socketio on status_update: %w", err)
+			si.errorLog.Printf("socketio on status_update: %v", err)
 		}
 
 		si.websocketHub.BroadcastToAll <- websocketMessage


### PR DESCRIPTION
## Summary
- Fix `%w` misuse in `log.Logger` calls (28 sites, 9 files) — `%w` is a `fmt.Errorf`-only verb; `log.Logger` has no error-wrapping support, so these printed the literal `%w` directive instead of the error. `Printf`/`Println` calls now use `%v`; one `Fatal` call found during the sweep (not caught by `go vet`, same bug pattern as `Println`) is now `Fatalf`.
- Retarget the stale `TestValidVersion` table in `pkg/api/helpers_test.go` at the real `oldestValidClientVersion` (`0.6.0`) boundary — it was written against `0.3.1` and 3 of 6 cases were failing.
- `gofmt -w pkg/models/models.go` (two `//X` → `// X` comment fixes).

This is prep work for adding CI (see follow-up PR) — `master` currently fails `go vet ./...` and `go test ./...`, which would make an immediate merge gate impossible.

## Test plan
- [x] `gofmt -l .` → empty
- [x] `go vet ./...` → clean
- [x] `go build ./...` → succeeds
- [x] `go test ./...` → passes