### PR TITLE
Build deploy binaries with CGO_ENABLED=0 for a static binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,8 @@ jobs:
       - name: Build server + collector
         run: |
           mkdir -p dist
-          GOOS=linux GOARCH=amd64 go build -trimpath -o dist/server ./cmd/server
-          GOOS=linux GOARCH=amd64 go build -trimpath -o dist/collector ./cmd/collector
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -o dist/server ./cmd/server
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -o dist/collector ./cmd/collector
 
       - uses: actions/setup-node@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ clean:
 	rm -f ./dist/collector
 
 build: clean
-	GOOS=linux GOARCH=amd64 go build -o dist/server -v ./cmd/server
-	GOOS=linux GOARCH=amd64 go build -o dist/collector -v ./cmd/collector
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o dist/server -v ./cmd/server
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o dist/collector -v ./cmd/collector
 
 deploy: build
 	scp ./dist/server casd:~/ddstats


### PR DESCRIPTION
The release deploy crash-looped in production: the binary linked against a glibc version newer than what's on the deploy host (GLIBC_2.32/2.34 not found). Building GOOS=linux GOARCH=amd64 on a Linux CI runner is a native build, not a cross-compile, so Go leaves CGO_ENABLED=1 by default and links dynamically against the runner's glibc. Cross-compiling from macOS (the prior manual `make deploy` path) never hit this because Go forces CGO_ENABLED=0 when no C cross-toolchain is available. Force it explicitly so the binary is portable regardless of which OS builds it.