### PR TITLE
Add .motd Discord command

### DIFF
--- a/pkg/discord/command.go
+++ b/pkg/discord/command.go
@@ -47,6 +47,7 @@ func (d *Discord) registerCommands() {
 	d.commandHelp()
 	d.commandMe()
 	d.commandRegister()
+	d.commandMOTD()
 }
 
 func fieldsFromPlayer(player *ddapi.Player) []*discordgo.MessageEmbedField {

--- a/pkg/discord/command_motd.go
+++ b/pkg/discord/command_motd.go
@@ -1,0 +1,54 @@
+package discord
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+const (
+	motdMaxLength          = 67
+	motdAuthorizedUsername = "vhsx"
+)
+
+func (d *Discord) commandMOTD() {
+	command := Command{
+		name:        "motd",
+		cooldown:    5 * time.Second,
+		description: "Set the message of the day shown to clients on login. Restricted to the bot owner.",
+		usage:       "<message>",
+		args:        true,
+		getEmbed: func(m *discordgo.MessageCreate, args ...string) *discordgo.MessageEmbed {
+			if !strings.EqualFold(m.Author.Username, motdAuthorizedUsername) {
+				return errorEmbed(fmt.Sprintf("You are not authorized to use this command. %s", m.Author.Mention()))
+			}
+
+			message := strings.TrimSpace(m.Content[len(prefix+"motd"):])
+			if message == "" {
+				return errorEmbed(fmt.Sprintf("Usage: %smotd %s", prefix, "<message>"))
+			}
+			if len(message) > motdMaxLength {
+				return errorEmbed(fmt.Sprintf("Message is %d characters, max is %d. %s", len(message), motdMaxLength, m.Author.Mention()))
+			}
+
+			err := d.DB.MOTD.Insert(message)
+			if err != nil {
+				d.errorLog.Printf("%v", err)
+				return errorEmbed(fmt.Sprintf("Failed to set the message of the day. %s", m.Author.Mention()))
+			}
+
+			return &discordgo.MessageEmbed{
+				Title:       "Message of the Day Updated",
+				Description: message,
+				Color:       defaultColor,
+				Footer: &discordgo.MessageEmbedFooter{
+					Text:    "ddstats.com",
+					IconURL: iconURL,
+				},
+			}
+		},
+	}
+	command.register(d)
+}

--- a/pkg/models/postgres/motd.go
+++ b/pkg/models/postgres/motd.go
@@ -30,3 +30,10 @@ func (m *MOTDModel) Get() (*models.MOTD, error) {
 	}
 	return &motd, nil
 }
+
+// Insert sets a new message of the day, which becomes the one returned by Get
+func (m *MOTDModel) Insert(message string) error {
+	stmt := `INSERT INTO message_of_the_day (message) VALUES ($1)`
+	_, err := m.DB.Exec(stmt, message)
+	return err
+}


### PR DESCRIPTION
## Summary
Currently the only way to change the message of the day is a raw `INSERT` against the `message_of_the_day` table (`Get()` always reads the highest-`id` row, so a fresh insert *is* the update). Adds a `.motd <message>` Discord command instead, following the existing one-command-per-file pattern in `pkg/discord`.

Since this command writes data rather than just reading it (unlike every other existing command), it's restricted to a single authorized Discord username (`vhsx`) via `strings.EqualFold` — anyone else gets an error embed instead. Also enforces the `message_of_the_day.message` column's 67-char limit before inserting, so it fails with a clear message rather than a DB error.

## Changes
* `pkg/models/postgres/motd.go` — `MOTDModel.Insert(message string) error`
* `pkg/discord/command_motd.go` — new `.motd` command, gated to `vhsx`
* `pkg/discord/command.go` — register it

## Test plan
- [x] `gofmt -l .`, `go vet ./...`, `go build ./...`, `go test ./...` all clean
- [ ] Manually test in Discord once deployed: `.motd <message>` as `vhsx` updates it; as anyone else, returns the "not authorized" embed; over 67 chars returns the length error