### PR TITLE
Truncate long player names in Top/Recent Games

### DIFF
--- a/ui/src/components/Home/RecentGames.vue
+++ b/ui/src/components/Home/RecentGames.vue
@@ -6,15 +6,15 @@
     <v-simple-table v-if="!loading">
       <tbody>
         <tr v-for="game in data.games" :key="game.id" @click="selectGame(game)" class="pointer">
-          <td class="dd-card-list-item-bold">
+          <td class="dd-card-list-item-bold truncate-name">
             <v-icon
               v-if="$root.checkPlayerLive(game.player_id)"
               class="icon online-green"
               small
             >mdi-access-point</v-icon>
-            {{ game.player_name }}
+            <span class="truncate-name-text" :title="game.player_name">{{ game.player_name }}</span>
           </td>
-          <td class="dd-card-list-item text-right">
+          <td class="dd-card-list-item text-right shrink-column">
             {{ game.game_time.toFixed(4) }}s
             <br />
             <span class="since-text">{{ moment(game.time_stamp).fromNow() }}...</span>
@@ -75,5 +75,23 @@ export default {
   font-family: "alte_haas_grotesk", "Helvetica Neue", Helvetica, Arial;
   font-style: oblique;
   font-size: 12px !important;
+}
+
+.truncate-name {
+  max-width: 0;
+}
+
+.shrink-column {
+  width: 1%;
+  white-space: nowrap;
+}
+
+.truncate-name-text {
+  display: inline-block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  vertical-align: middle;
 }
 </style>

--- a/ui/src/components/Home/TopGames.vue
+++ b/ui/src/components/Home/TopGames.vue
@@ -6,15 +6,15 @@
     <v-simple-table v-if="!loading">
       <tbody>
         <tr v-for="game in data.games" :key="game.id" @click="selectGame(game)" class="pointer">
-          <td class="dd-card-list-item-bold">
+          <td class="dd-card-list-item-bold truncate-name">
             <v-icon
               v-if="$root.checkPlayerLive(game.player_id)"
               class="icon online-green"
               small
             >mdi-access-point</v-icon>
-            {{ game.player_name }}
+            <span class="truncate-name-text" :title="game.player_name">{{ game.player_name }}</span>
           </td>
-          <td class="dd-card-list-item text-right">{{ game.game_time.toFixed(4) }}s</td>
+          <td class="dd-card-list-item text-right shrink-column">{{ game.game_time.toFixed(4) }}s</td>
         </tr>
       </tbody>
     </v-simple-table>
@@ -61,5 +61,23 @@ export default {
   font-family: "alte_haas_grotesk", "Helvetica Neue", Helvetica, Arial;
   font-style: oblique;
   font-size: 12px !important;
+}
+
+.truncate-name {
+  max-width: 0;
+}
+
+.shrink-column {
+  width: 1%;
+  white-space: nowrap;
+}
+
+.truncate-name-text {
+  display: inline-block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  vertical-align: middle;
 }
 </style>


### PR DESCRIPTION
## Summary

* Long player names in the Top Games / Recent Games sidebar cards pushed the game time column off-screen.
* Truncate the name with an ellipsis, cap the time column to its own content width (it was ballooning and starving the name column), and show the full name via the native `title` tooltip on hover.

## Test plan

- [x] Verified locally in the browser (chrome-devtools MCP) with real production data — long names truncate sensibly, time column stays visible, hovering shows the full name via tooltip
- [x] `yarn lint --no-fix src` — no new errors (only pre-existing prettier warnings)
- [x] `yarn build` succeeds