### PR TITLE
Add .news Discord command to update website News feed

### DIFF
--- a/pkg/discord/command.go
+++ b/pkg/discord/command.go
@@ -2,6 +2,7 @@ package discord
 
 import (
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/alexwilkerson/ddstats-server/pkg/ddapi"
@@ -14,6 +15,12 @@ const (
 	defaultColor = 0xC33409 // dark reddish color
 	iconURL      = "https://ddstats.com/static/ddstats_logo_v2_red_100px.png"
 )
+
+const botOwnerUsername = "vhsx"
+
+func isBotOwner(u *discordgo.User) bool {
+	return strings.EqualFold(u.Username, botOwnerUsername)
+}
 
 const (
 	secondsInDay = 86400
@@ -48,6 +55,7 @@ func (d *Discord) registerCommands() {
 	d.commandMe()
 	d.commandRegister()
 	d.commandMOTD()
+	d.commandNews()
 }
 
 func fieldsFromPlayer(player *ddapi.Player) []*discordgo.MessageEmbedField {

--- a/pkg/discord/command_news.go
+++ b/pkg/discord/command_news.go
@@ -8,13 +8,11 @@ import (
 	"github.com/bwmarrin/discordgo"
 )
 
-const motdMaxLength = 67
-
-func (d *Discord) commandMOTD() {
+func (d *Discord) commandNews() {
 	command := Command{
-		name:        "motd",
+		name:        "news",
 		cooldown:    5 * time.Second,
-		description: "Set the message of the day shown to clients on login. Restricted to the bot owner.",
+		description: "Post a new entry to the News feed on the website. Restricted to the bot owner.",
 		usage:       "<message>",
 		args:        true,
 		getEmbed: func(m *discordgo.MessageCreate, args ...string) *discordgo.MessageEmbed {
@@ -22,22 +20,19 @@ func (d *Discord) commandMOTD() {
 				return errorEmbed(fmt.Sprintf("You are not authorized to use this command. %s", m.Author.Mention()))
 			}
 
-			message := strings.TrimSpace(m.Content[len(prefix+"motd"):])
+			message := strings.TrimSpace(m.Content[len(prefix+"news"):])
 			if message == "" {
-				return errorEmbed(fmt.Sprintf("Usage: %smotd %s", prefix, "<message>"))
-			}
-			if len(message) > motdMaxLength {
-				return errorEmbed(fmt.Sprintf("Message is %d characters, max is %d. %s", len(message), motdMaxLength, m.Author.Mention()))
+				return errorEmbed(fmt.Sprintf("Usage: %snews %s", prefix, "<message>"))
 			}
 
-			err := d.DB.MOTD.Insert(message)
+			err := d.DB.News.Insert(message)
 			if err != nil {
 				d.errorLog.Printf("%v", err)
-				return errorEmbed(fmt.Sprintf("Failed to set the message of the day. %s", m.Author.Mention()))
+				return errorEmbed(fmt.Sprintf("Failed to post the news entry. %s", m.Author.Mention()))
 			}
 
 			return &discordgo.MessageEmbed{
-				Title:       "Message of the Day Updated",
+				Title:       "News Posted",
 				Description: message,
 				Color:       defaultColor,
 				Footer: &discordgo.MessageEmbedFooter{

--- a/pkg/models/postgres/news.go
+++ b/pkg/models/postgres/news.go
@@ -43,6 +43,13 @@ func (nm *NewsModel) GetAll(pageSize, pageNum int) ([]*models.News, error) {
 	return news, nil
 }
 
+// Insert adds a new news post, shown at the top of the News feed on the website
+func (nm *NewsModel) Insert(body string) error {
+	stmt := `INSERT INTO news (body) VALUES ($1)`
+	_, err := nm.DB.Exec(stmt, body)
+	return err
+}
+
 func (nm *NewsModel) GetTotalCount() (int, error) {
 	var count int
 	stmt := `


### PR DESCRIPTION
## Summary

* Adds a `.news <message>` Discord command, mirroring `.motd`, that inserts a row into the `news` table — the same source the homepage's News card (`News.vue`) already reads via `/api/v2/news`.
* Restricted to the bot owner (Discord username `vhsx`), same as `.motd`.
* Extracted the bot-owner check into a shared `isBotOwner` helper in `command.go` since it's now used by two commands, and updated `.motd` to use it instead of its own local constant.

## Changes

* `pkg/models/postgres/news.go` — `Insert(body string) error`
* `pkg/discord/command_news.go` — new `.news` command
* `pkg/discord/command.go` — registers `.news`, adds shared `isBotOwner` helper
* `pkg/discord/command_motd.go` — uses `isBotOwner` instead of duplicating the check

## Test plan

- [x] `gofmt -l .`, `go vet ./...`, `go build ./...`, `go test ./...` all clean